### PR TITLE
Removing Max Width Media Queries

### DIFF
--- a/css/skeleton.ontraport.css
+++ b/css/skeleton.ontraport.css
@@ -190,20 +190,6 @@ Container
     max-width: 1200px;
 }
 
-/* For devices larger than 400px */
-@media (min-width: 400px) {
-  .container.container {
-    max-width: 85%;
-  }
-}
-
-/* For devices larger than 550px */
-@media (min-width: 550px) {
-  .container.container {
-    max-width: 80%; 
-  }
-}
-
 /* =====================================================================================================================
 Forms
 ===================================================================================================================== */


### PR DESCRIPTION
Removing max width media queries that allow block containers to grow past the desired 1200px max width.
