### PR TITLE
Hide the up/down spinner elements for date input types

### DIFF
--- a/css/skeleton.ontraport.css
+++ b/css/skeleton.ontraport.css
@@ -234,9 +234,15 @@ input[type="date"] {
   box-sizing: border-box; 
   -webkit-appearance: none;
      -moz-appearance: none;
-          appearance: none; 
+          appearance: none;
+
 }
 input[type="date"]:focus {
   border: 1px solid #33C3F0;
   outline: 0; 
+}
+
+/* Hide the up/down spinner control for Chrome. You can still use the keyboard to edit the values */
+input[type="date"]::-webkit-inner-spin-button {
+    display: none;
 }


### PR DESCRIPTION
Hide the up/down spinner controls for date input types. The functionality is still present, so the values will change if the up/down keys are pressed on the keyboard.
